### PR TITLE
Removing meta-package 'php7.0' installation in favor of php_packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,6 @@ php_packages:
   - php7.0-fpm
   - php7.0-mysql
   - php7.0-gd
-#  - php7.0-mbstring
   - php7.0-mcrypt
 php_timezone: Europe/Warsaw
 php_upload_max_filesize: "20M"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,10 +18,6 @@
   become: yes
   apt: update_cache=yes
 
-- name: Install PHP
-  become: yes
-  apt: pkg=php7.0 state=latest
-
 - name: Install PHP Packages
   become: yes
   apt: pkg={{ item }} state=latest


### PR DESCRIPTION
In order to prevent apache2 to be installed by this role, the installation of
the meta-package 'php7.0' has been removed.

The installation of the packages listed in the default php_packages is web
server agnostic.