### PR TITLE
Add privileges escalation on php7 restart handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: restart php7-fpm
   service: name=php7.0-fpm enabled=yes state=restarted
+  become: yes


### PR DESCRIPTION
I had an access denied exception when ansible tried to restart php7 fpm

```
RUNNING HANDLER [itcraftsmanpl.php7 : restart php7-fpm] ************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "Unable to restart service php7.0-fpm: Failed to restart php7.0-fpm.service: Access denied\n"}
```