### PR TITLE
Support for PHP 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ https://galaxy.ansible.com/itcraftsmanpl/php7/
 
 An Ansible role that installs and configure PHP 7 on Debian/Ubuntu servers.
 
-Current PHP7 version: **7.1.2**
+Current PHP7 version: **7.2.23**
 
 ## Requirements
 
@@ -18,16 +18,15 @@ Available variables are listed below, along with default values (see `defaults/m
 
     php_ppa: "ppa:ondrej/php"
     php_packages:
-      - php7.1-common
-      - php7.1-cli
-      - php7.1-intl
-      - php7.1-curl
-      - php7.1-cgi
-      - php7.1-fpm
-      - php7.1-mysql
-      - php7.1-gd
-      - php7.1-mbstring
-      - php7.1-mcrypt
+      - php7.2-common
+      - php7.2-cli
+      - php7.2-intl
+      - php7.2-curl
+      - php7.2-cgi
+      - php7.2-fpm
+      - php7.2-mysql
+      - php7.2-gd
+      - php7.2-mbstring
     php_timezone: Europe/Warsaw
     php_upload_max_filesize: "20M"
     php_post_max_size: "20M"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Role: PHP7
 
-https://galaxy.ansible.com/itcraftsmanpl/php7/
+https://galaxy.ansible.com/akondas/php7
 
 An Ansible role that installs and configure PHP 7 on Debian/Ubuntu servers.
 
@@ -51,7 +51,7 @@ None.
 
     - hosts: webservers
       roles:
-        - { role: itcraftsmanpl.php7 }
+        - { role: akondas.php7 }
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,16 +1,15 @@
 ---
 php_ppa: "ppa:ondrej/php"
 php_packages:
-  - php7.1-common
-  - php7.1-cli
-  - php7.1-intl
-  - php7.1-curl
-  - php7.1-cgi
-  - php7.1-fpm
-  - php7.1-mysql
-  - php7.1-gd
-  - php7.1-mcrypt
-  - php7.1-mbstring
+  - php7.2-common
+  - php7.2-cli
+  - php7.2-intl
+  - php7.2-curl
+  - php7.2-cgi
+  - php7.2-fpm
+  - php7.2-mysql
+  - php7.2-gd
+  - php7.2-mbstring
 php_timezone: Europe/Warsaw
 php_upload_max_filesize: "20M"
 php_post_max_size: "20M"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: restart php7-fpm
-  service: name=php7.1-fpm enabled=yes state=restarted
+  service: name=php7.2-fpm enabled=yes state=restarted
   become: yes

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,8 +1,8 @@
 ---
-- stat: path=/etc/php/7.1/fpm/php.ini
+- stat: path=/etc/php/7.2/fpm/php.ini
   register: phpfpm
 
-- stat: path=/etc/php/7.1/cli/php.ini
+- stat: path=/etc/php/7.2/cli/php.ini
   register: phpcli
 
 - include: php-fpm.yml

--- a/tasks/php-cli.yml
+++ b/tasks/php-cli.yml
@@ -1,10 +1,10 @@
 ---
 - name: Ensure timezone is set in cli php.ini
-  lineinfile: dest=/etc/php/7.1/cli/php.ini
+  lineinfile: dest=/etc/php/7.2/cli/php.ini
               regexp='date.timezone ='
               line='date.timezone = {{ php_timezone }}'
 
 - name: disabling opcache cli
-  lineinfile: dest=/etc/php/7.1/cli/php.ini
+  lineinfile: dest=/etc/php/7.2/cli/php.ini
               regexp='opcache.enable_cli='
               line='opcache.enable_cli=0'

--- a/tasks/php-fpm.yml
+++ b/tasks/php-fpm.yml
@@ -43,19 +43,7 @@
               line='allow_url_fopen = {{ php_allow_url_fopen }}'
   notify: restart php7-fpm
 
-- name: Change soap.wsdl_cache_dir to new directory
-  lineinfile: dest=/etc/php/7.2/fpm/php.ini
-              regexp='soap.wsdl_cache_dir(\s)?='
-              line='soap.wsdl_cache_dir=/php/cache/wsdl'
-  notify: restart php7-fpm
-
-- name: Change upload_tmp_dir path
-  lineinfile: dest=/etc/php/7.2/fpm/php.ini
-              regexp='upload_tmp_dir(\s)?='
-              line='upload_tmp_dir=/php/cache/upload_tmp'
-  notify: restart php7-fpm
-
-- name: Exclude potentially harmfull php functions
+- name: Exclude potentially harmful php functions
   lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='disable_functions(\s)?='
               line='disable_functions=exec,passthru,shell_exec,system,proc_open,popen'

--- a/tasks/php-fpm.yml
+++ b/tasks/php-fpm.yml
@@ -1,135 +1,135 @@
 ---
 - name: Set permissions on socket - owner
-  lineinfile: "dest=/etc/php/7.1/fpm/pool.d/www.conf state=present regexp='^;?listen.owner' line='listen.owner = www-data'"
+  lineinfile: "dest=/etc/php/7.2/fpm/pool.d/www.conf state=present regexp='^;?listen.owner' line='listen.owner = www-data'"
 
 - name: Set permissions on socket - group
-  lineinfile: "dest=/etc/php/7.1/fpm/pool.d/www.conf state=present regexp='^;?listen.group' line='listen.group = www-data'"
+  lineinfile: "dest=/etc/php/7.2/fpm/pool.d/www.conf state=present regexp='^;?listen.group' line='listen.group = www-data'"
 
 - name: Set permissions on socket - mode
-  lineinfile: "dest=/etc/php/7.1/fpm/pool.d/www.conf state=present regexp='^;?listen.mode' line='listen.mode = 0660'"
+  lineinfile: "dest=/etc/php/7.2/fpm/pool.d/www.conf state=present regexp='^;?listen.mode' line='listen.mode = 0660'"
   notify: restart php7-fpm
 
 - name: Ensure timezone is set in fpm php.ini
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='date.timezone ='
               line='date.timezone = {{ php_timezone }}'
 
 - name: Enabling opcache
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='^#?opcache.enable='
               line='opcache.enable=1'
 
 - name: Opcache - changing revalidate frequency to 0
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='opcache.revalidate_freq='
               line='opcache.revalidate_freq=0'
   tags: [ development ]
 
 - name: Set session.cookie_httponly to `true`
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='session.cookie_httponly(\s)?='
               line='session.cookie_httponly=1'
   notify: restart php7-fpm
 
 - name: Enable session strict mode
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='session.use_strict_mode(\s)?='
               line='session.use_strict_mode = 1'
   notify: restart php7-fpm
 
 - name: Set allow_url_fopen
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='allow_url_fopen(\s)?='
               line='allow_url_fopen = {{ php_allow_url_fopen }}'
   notify: restart php7-fpm
 
 - name: Change soap.wsdl_cache_dir to new directory
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='soap.wsdl_cache_dir(\s)?='
               line='soap.wsdl_cache_dir=/php/cache/wsdl'
   notify: restart php7-fpm
 
 - name: Change upload_tmp_dir path
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='upload_tmp_dir(\s)?='
               line='upload_tmp_dir=/php/cache/upload_tmp'
   notify: restart php7-fpm
 
 - name: Exclude potentially harmfull php functions
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='disable_functions(\s)?='
               line='disable_functions=exec,passthru,shell_exec,system,proc_open,popen'
   notify: restart php7-fpm
 
 - name: Set post_max_size
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='post_max_size(\s)?='
               line='post_max_size = {{ php_post_max_size }}'
   notify: restart php7-fpm
 
 - name: Set upload_max_filesize
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='upload_max_filesize(\s)?='
               line='upload_max_filesize = {{ php_upload_max_filesize }}'
               create=yes
   notify: restart php7-fpm
 
 - name: Set memory_limit
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='memory_limit(\s)?='
               line='memory_limit = {{ php_memory_limit }}'
   notify: restart php7-fpm
 
 - name: Set max_execution_time
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='max_execution_time(\s)?='
               line='max_execution_time = {{ php_max_execution_time }}'
   notify: restart php7-fpm
 
 - name: enabling opcache
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='opcache.enable='
               line='opcache.enable={{ php_opcache_enable }}'
               insertafter="^[opcache]"
   notify: restart php7-fpm
 
 - name: opcache - changing revalidate frequency
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='opcache.revalidate_freq='
               line='opcache.revalidate_freq={{ php_opcache_revalidate_freq }}'
               insertafter="^[opcache]"
   notify: restart php7-fpm
 
 - name: opcache - changing validate timestamps
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='opcache.validate_timestamps='
               line='opcache.validate_timestamps={{ php_opcache_opcache_validate_timestamps }}'
               insertafter="^[opcache]"
   notify: restart php7-fpm
 
 - name: opcache - changing max accelerated files
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='opcache.max_accelerated_files='
               line='opcache.max_accelerated_files={{ php_opcache_max_accelerated_files }}'
               insertafter="^[opcache]"
   notify: restart php7-fpm
 
 - name: opcache - memory consumption
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='opcache.memory_consumption='
               line='opcache.memory_consumption={{ php_opcache_memory_consumption }}'
               insertafter="^[opcache]"
   notify: restart php7-fpm
 
 - name: opcache - interned strings buffer
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='opcache.interned_strings_buffer='
               line='opcache.interned_strings_buffer={{ php_opcache_interned_strings_buffer }}'
               insertafter="^[opcache]"
   notify: restart php7-fpm
 
 - name: opcache - fast shutdown
-  lineinfile: dest=/etc/php/7.1/fpm/php.ini
+  lineinfile: dest=/etc/php/7.2/fpm/php.ini
               regexp='opcache.fast_shutdown='
               line='opcache.fast_shutdown={{ php_opcache_fast_shutdown }}'
               insertafter="^[opcache]"


### PR DESCRIPTION
I updated all packages to use PHP 7.2. mcrypt is no longer available for this PHP version.
https://www.php.net/manual/en/intro.mcrypt.php